### PR TITLE
fix: only store meta_tags in patch when user explicitly changed it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,24 @@ Uses [Taskfile](https://taskfile.dev/):
 - Database transactions use a `tx` helper pattern
 - Kafka messages use manual protowire encoding (no generated Go protobuf code)
 - External wiki API calls go through `api.go` client methods
+
+## Patch Field Change Detection
+
+Each patch table (subject_patch, character_patch, person_patch, episode_patch) uses **NULL vs non-NULL** to distinguish which fields the user explicitly modified:
+
+- **NULL** — user did not submit/change this field
+- **non-NULL** — user provided a new value
+
+The `original_*` columns always store the baseline wiki value at submission time (used for conflict detection during approval). They are unconditionally populated regardless of which fields changed.
+
+Example for `subject_patch`:
+
+| Column | NULL? | Meaning |
+|---|---|---|
+| `name` | non-NULL | user changed the name |
+| `name` | NULL | user did not change the name |
+| `meta_tags` | non-NULL | user changed meta_tags |
+| `meta_tags` | NULL | user did not change meta_tags |
+| `original_meta_tags` | always non-NULL | baseline for conflict detection |
+
+When building patch creation/update handlers, only set the field column when the user's value actually differs from the original. Never unconditionally assign a field column — doing so would incorrectly mark an unchanged field as "user modified" and produce spurious diffs.

--- a/subject.go
+++ b/subject.go
@@ -803,11 +803,11 @@ func (h *handler) deleteSubjectPatch(w http.ResponseWriter, r *http.Request) err
 const contentTypeApplicationJSON = "application/json"
 
 type RequestToUpdateSubject struct {
-	Name     null.String `json:"name"`
-	Infobox  null.String `json:"infobox"`
-	Summary  null.String `json:"summary"`
+	Name     null.String         `json:"name"`
+	Infobox  null.String         `json:"infobox"`
+	Summary  null.String         `json:"summary"`
 	MetaTags null.Null[[]string] `json:"metaTags"`
-	Nsfw     null.Bool   `json:"nsfw"`
+	Nsfw     null.Bool           `json:"nsfw"`
 
 	Reason    string `json:"reason"`
 	PatchDesc string `json:"patch_desc"`

--- a/subject.go
+++ b/subject.go
@@ -337,13 +337,11 @@ func (h *handler) subjectPatchDetailView(
 		})
 	}
 
-	if patch.MetaTags != nil || patch.OriginalMetaTags != nil {
-		if !metaTagsEqual(patch.OriginalMetaTags, patch.MetaTags) {
-			changes = append(changes, view.Change{
-				Name: "公共标签",
-				Diff: diff.Diff("meta_tags", strings.Join(patch.OriginalMetaTags, " "), strings.Join(patch.MetaTags, " ")),
-			})
-		}
+	if patch.MetaTags != nil && !metaTagsEqual(patch.OriginalMetaTags, patch.MetaTags) {
+		changes = append(changes, view.Change{
+			Name: "公共标签",
+			Diff: diff.Diff("meta_tags", strings.Join(patch.OriginalMetaTags, " "), strings.Join(patch.MetaTags, " ")),
+		})
 	}
 
 	return templates.SubjectPatchPage(
@@ -480,9 +478,9 @@ func (h *handler) createSubjectEditPatch(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	param.MetaTags = metaTags
 	if !metaTagsEqual(originalWiki.MetaTags, metaTags) {
 		changed = true
+		param.MetaTags = metaTags
 	}
 
 	// Compare NSFW status
@@ -808,7 +806,7 @@ type RequestToUpdateSubject struct {
 	Name     null.String `json:"name"`
 	Infobox  null.String `json:"infobox"`
 	Summary  null.String `json:"summary"`
-	MetaTags *[]string   `json:"metaTags"`
+	MetaTags null.Null[[]string] `json:"metaTags"`
 	Nsfw     null.Bool   `json:"nsfw"`
 
 	Reason    string `json:"reason"`
@@ -943,9 +941,9 @@ func (h *handler) createSubjectEditPatchAPI(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	if req.MetaTags != nil && !metaTagsEqual(*req.MetaTags, originalWiki.MetaTags) {
+	if req.MetaTags.Set && !metaTagsEqual(req.MetaTags.Value, originalWiki.MetaTags) {
 		changed = true
-		param.MetaTags = *req.MetaTags
+		param.MetaTags = req.MetaTags.Value
 	}
 
 	if !changed {


### PR DESCRIPTION
## Summary

- Fix `createSubjectEditPatchAPI`: when `metaTags` is not provided in the API request, the patch should not store meta_tags data (DB column stays NULL)
- Fix `createSubjectEditPatch` (form handler): only set `param.MetaTags` when tags actually changed, consistent with the NULL semantics
- Fix diff view: use `patch.MetaTags != nil` to check if user submitted meta_tags, instead of `patch.MetaTags != nil || patch.OriginalMetaTags != nil` (which always true since `OriginalMetaTags` is always set)
- Use `null.Null[[]string]` for `MetaTags` in API request struct, consistent with other fields

## Background

The DB uses `meta_tags` column NULL vs non-NULL to distinguish whether the user submitted meta_tags. Previously, the API handler always set `OriginalMetaTags` but only conditionally set `MetaTags`, causing patches without meta_tags changes to show a spurious diff (original tags → empty).
