### PR TITLE
feat: derive Debezium topics from prefix instead of full topic list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ REDIS_DSN="redis://..."
 
 PG_DSN="postgresql://..."
 
+# Debezium CDC: consumer 按 {KAFKA_TOPIC_PREFIX}.{table} 自动订阅
+# 表列表见 canal.go 中的 canalTables
+KAFKA_BROKER="..."
+KAFKA_TOPIC_PREFIX="debezium.chii.bangumi"
+
 SERVER_BASE_URL="http://127.0.0.1:8000"
 
 CSRF_SECRET_TOKEN="a-development-token-should-not-be-used-in-production"

--- a/canal.go
+++ b/canal.go
@@ -16,6 +16,14 @@ import (
 
 const canalGroupID = "submit-patch-canal"
 
+// Debezium topic 命名格式为 {prefix}.{table}，这里维护本服务需要监听的表。
+// 必须与 handleCanalMessage 的 switch 分支保持一致。
+var canalTables = []string{
+	"chii_subjects",
+	"chii_characters",
+	"chii_persons",
+}
+
 const opUpdate = "u"
 
 type debeziumPayload struct {
@@ -59,10 +67,15 @@ type personAfter struct {
 }
 
 func startCanalConsumer(ctx context.Context, cfg Config, h *handler) error {
+	topics := make([]string, 0, len(canalTables))
+	for _, t := range canalTables {
+		topics = append(topics, cfg.KafkaTopicPrefix+"."+t)
+	}
+
 	r := kafka.NewReader(kafka.ReaderConfig{
 		Brokers:     []string{cfg.KafkaBroker},
 		GroupID:     canalGroupID,
-		GroupTopics: cfg.KafkaTopics,
+		GroupTopics: topics,
 	})
 	defer r.Close()
 

--- a/config.go
+++ b/config.go
@@ -26,8 +26,8 @@ type Config struct {
 	TurnstileSiteKey   string `env:"TURNSTILE_SITE_KEY"`
 	TurnstileSecretKey string `env:"TURNSTILE_SECRET_KEY"`
 
-	KafkaBroker string   `env:"KAFKA_BROKER"`
-	KafkaTopics []string `env:"KAFKA_TOPICS"`
+	KafkaBroker      string `env:"KAFKA_BROKER"`
+	KafkaTopicPrefix string `env:"KAFKA_TOPIC_PREFIX"`
 }
 
 func newConfig() (Config, error) {

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"slices"
 	"syscall"
 	"time"
 
@@ -98,8 +97,7 @@ func main() {
 		return nil
 	})
 
-	c.KafkaTopics = slices.DeleteFunc(c.KafkaTopics, func(s string) bool { return s == "" })
-	if c.KafkaBroker != "" && len(c.KafkaTopics) > 0 {
+	if c.KafkaBroker != "" && c.KafkaTopicPrefix != "" {
 		g.Go(func() error {
 			return startCanalConsumer(ctx, c, h)
 		})


### PR DESCRIPTION
## Summary

Previously the canal consumer required manually maintaining the full Debezium topic list via `KAFKA_TOPICS` (e.g. `debezium.chii.bangumi.chii_subjects,debezium.chii.bangumi.chii_characters,...`). Missing a topic silently disables auto-outdating for that patch type.

Now only the topic prefix needs to be configured via `KAFKA_TOPIC_PREFIX` (e.g. `debezium.chii.bangumi`). The consumer derives the topic list from a hardcoded `canalTables` slice in `canal.go`, which is kept in sync with the `handleCanalMessage` switch.

## Changes

- `config.go`: replace `KafkaTopics []string` (`KAFKA_TOPICS`) with `KafkaTopicPrefix string` (`KAFKA_TOPIC_PREFIX`)
- `canal.go`: add `canalTables` (chii_subjects / chii_characters / chii_persons); `startCanalConsumer` builds `{prefix}.{table}` topics
- `main.go`: start consumer when `KAFKA_BROKER` and `KAFKA_TOPIC_PREFIX` are both set; drop the now-unused `slices` cleanup
- `.env.example`: document the new env vars

## Breaking change

Deployment must replace `KAFKA_TOPICS` with `KAFKA_TOPIC_PREFIX` (and keep `KAFKA_BROKER` set), otherwise the canal consumer will not start.