### PR TITLE
fix(canal): skip expired notification when patch is no longer pending

### DIFF
--- a/canal.go
+++ b/canal.go
@@ -162,16 +162,21 @@ func handleSubjectChange(ctx context.Context, h *handler, key []byte, afterRaw j
 		if !subjectPatchIsOutdated(patch, after) {
 			continue
 		}
-		if err := h.q.RejectSubjectPatch(ctx, dal.RejectSubjectPatchParams{
+		affected, err := h.q.RejectSubjectPatch(ctx, dal.RejectSubjectPatchParams{
 			WikiUserID:   0,
 			State:        PatchStateOutdated,
 			RejectReason: "条目已被修改，建议已过期",
 			ID:           patch.ID,
-		}); err != nil {
+		})
+		if err != nil {
 			log.Error().Err(err).Stringer("id", patch.ID).Msg("canal: failed to mark subject patch outdated")
-		} else {
-			h.sendNotifySubjectPatchExpired(ctx, patch.NumID, patch.FromUserID)
+			continue
 		}
+		if affected == 0 {
+			// patch 状态已被其他流程（如接受）改变，跳过过期通知，避免误报
+			continue
+		}
+		h.sendNotifySubjectPatchExpired(ctx, patch.NumID, patch.FromUserID)
 	}
 	return nil
 }
@@ -217,16 +222,21 @@ func handleCharacterChange(ctx context.Context, h *handler, key []byte, afterRaw
 		if !characterPatchIsOutdated(patch, after) {
 			continue
 		}
-		if err := h.q.RejectCharacterPatch(ctx, dal.RejectCharacterPatchParams{
+		affected, err := h.q.RejectCharacterPatch(ctx, dal.RejectCharacterPatchParams{
 			WikiUserID:   0,
 			State:        PatchStateOutdated,
 			RejectReason: "角色已被修改，建议已过期",
 			ID:           patch.ID,
-		}); err != nil {
+		})
+		if err != nil {
 			log.Error().Err(err).Stringer("id", patch.ID).Msg("canal: failed to mark character patch outdated")
-		} else {
-			h.sendNotifyCharacterPatchExpired(ctx, patch.NumID, patch.FromUserID)
+			continue
 		}
+		if affected == 0 {
+			// patch 状态已被其他流程（如接受）改变，跳过过期通知，避免误报
+			continue
+		}
+		h.sendNotifyCharacterPatchExpired(ctx, patch.NumID, patch.FromUserID)
 	}
 	return nil
 }
@@ -272,16 +282,21 @@ func handlePersonChange(ctx context.Context, h *handler, key []byte, afterRaw js
 		if !personPatchIsOutdated(patch, after) {
 			continue
 		}
-		if err := h.q.RejectPersonPatch(ctx, dal.RejectPersonPatchParams{
+		affected, err := h.q.RejectPersonPatch(ctx, dal.RejectPersonPatchParams{
 			WikiUserID:   0,
 			State:        PatchStateOutdated,
 			RejectReason: "人物已被修改，建议已过期",
 			ID:           patch.ID,
-		}); err != nil {
+		})
+		if err != nil {
 			log.Error().Err(err).Stringer("id", patch.ID).Msg("canal: failed to mark person patch outdated")
-		} else {
-			h.sendNotifyPersonPatchExpired(ctx, patch.NumID, patch.FromUserID)
+			continue
 		}
+		if affected == 0 {
+			// patch 状态已被其他流程（如接受）改变，跳过过期通知，避免误报
+			continue
+		}
+		h.sendNotifyPersonPatchExpired(ctx, patch.NumID, patch.FromUserID)
 	}
 	return nil
 }

--- a/character-review.go
+++ b/character-review.go
@@ -108,7 +108,7 @@ func (h *handler) handleCharacterApprove(w http.ResponseWriter, r *http.Request,
 		}
 
 		if errRes.Code == ErrCodeInvalidWikiSyntax {
-			err = qx.RejectCharacterPatch(r.Context(), dal.RejectCharacterPatchParams{
+			_, err = qx.RejectCharacterPatch(r.Context(), dal.RejectCharacterPatchParams{
 				WikiUserID:   s.UserID,
 				State:        PatchStateRejected,
 				ID:           patch.ID,
@@ -125,7 +125,7 @@ func (h *handler) handleCharacterApprove(w http.ResponseWriter, r *http.Request,
 		}
 
 		if errRes.Code == ErrCodeWikiChanged {
-			err = qx.RejectCharacterPatch(r.Context(), dal.RejectCharacterPatchParams{
+			_, err = qx.RejectCharacterPatch(r.Context(), dal.RejectCharacterPatchParams{
 				WikiUserID:   s.UserID,
 				State:        PatchStateOutdated,
 				ID:           patch.ID,
@@ -142,7 +142,7 @@ func (h *handler) handleCharacterApprove(w http.ResponseWriter, r *http.Request,
 		}
 
 		if errRes.Code == ErrCodeItemLocked {
-			err = qx.RejectCharacterPatch(r.Context(), dal.RejectCharacterPatchParams{
+			_, err = qx.RejectCharacterPatch(r.Context(), dal.RejectCharacterPatchParams{
 				WikiUserID:   s.UserID,
 				State:        PatchStateRejected,
 				ID:           patch.ID,
@@ -159,7 +159,7 @@ func (h *handler) handleCharacterApprove(w http.ResponseWriter, r *http.Request,
 		}
 
 		if errRes.Code == ErrCodeValidationError {
-			err = qx.RejectCharacterPatch(r.Context(), dal.RejectCharacterPatchParams{
+			_, err = qx.RejectCharacterPatch(r.Context(), dal.RejectCharacterPatchParams{
 				WikiUserID:   s.UserID,
 				State:        PatchStateRejected,
 				ID:           patch.ID,
@@ -177,7 +177,7 @@ func (h *handler) handleCharacterApprove(w http.ResponseWriter, r *http.Request,
 		return errors.New("failed to submit patch")
 	}
 
-	err = qx.AcceptCharacterPatch(context.WithoutCancel(r.Context()), dal.AcceptCharacterPatchParams{
+	_, err = qx.AcceptCharacterPatch(context.WithoutCancel(r.Context()), dal.AcceptCharacterPatchParams{
 		WikiUserID: s.UserID,
 		State:      PatchStateAccepted,
 		ID:         patch.ID,
@@ -203,7 +203,7 @@ func (h *handler) handleCharacterApprove(w http.ResponseWriter, r *http.Request,
 }
 
 func (h *handler) handleCharacterReject(w http.ResponseWriter, r *http.Request, qx *dal.Queries, p dal.CharacterPatch, s *session.Session) error {
-	err := qx.RejectCharacterPatch(r.Context(), dal.RejectCharacterPatchParams{
+	_, err := qx.RejectCharacterPatch(r.Context(), dal.RejectCharacterPatchParams{
 		WikiUserID: s.UserID,
 		State:      PatchStateRejected,
 		ID:         p.ID,

--- a/dal/query.sql.go
+++ b/dal/query.sql.go
@@ -12,7 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-const acceptCharacterPatch = `-- name: AcceptCharacterPatch :exec
+const acceptCharacterPatch = `-- name: AcceptCharacterPatch :execrows
 update character_patch
 set wiki_user_id = $1,
     state        = $2,
@@ -28,9 +28,12 @@ type AcceptCharacterPatchParams struct {
 	ID         uuid.UUID
 }
 
-func (q *Queries) AcceptCharacterPatch(ctx context.Context, arg AcceptCharacterPatchParams) error {
-	_, err := q.db.Exec(ctx, acceptCharacterPatch, arg.WikiUserID, arg.State, arg.ID)
-	return err
+func (q *Queries) AcceptCharacterPatch(ctx context.Context, arg AcceptCharacterPatchParams) (int64, error) {
+	result, err := q.db.Exec(ctx, acceptCharacterPatch, arg.WikiUserID, arg.State, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const acceptEpisodePatch = `-- name: AcceptEpisodePatch :exec
@@ -54,7 +57,7 @@ func (q *Queries) AcceptEpisodePatch(ctx context.Context, arg AcceptEpisodePatch
 	return err
 }
 
-const acceptPersonPatch = `-- name: AcceptPersonPatch :exec
+const acceptPersonPatch = `-- name: AcceptPersonPatch :execrows
 update person_patch
 set wiki_user_id = $1,
     state        = $2,
@@ -70,12 +73,15 @@ type AcceptPersonPatchParams struct {
 	ID         uuid.UUID
 }
 
-func (q *Queries) AcceptPersonPatch(ctx context.Context, arg AcceptPersonPatchParams) error {
-	_, err := q.db.Exec(ctx, acceptPersonPatch, arg.WikiUserID, arg.State, arg.ID)
-	return err
+func (q *Queries) AcceptPersonPatch(ctx context.Context, arg AcceptPersonPatchParams) (int64, error) {
+	result, err := q.db.Exec(ctx, acceptPersonPatch, arg.WikiUserID, arg.State, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
-const acceptSubjectPatch = `-- name: AcceptSubjectPatch :exec
+const acceptSubjectPatch = `-- name: AcceptSubjectPatch :execrows
 update subject_patch
 set wiki_user_id = $1,
     state        = $2,
@@ -91,9 +97,12 @@ type AcceptSubjectPatchParams struct {
 	ID         uuid.UUID
 }
 
-func (q *Queries) AcceptSubjectPatch(ctx context.Context, arg AcceptSubjectPatchParams) error {
-	_, err := q.db.Exec(ctx, acceptSubjectPatch, arg.WikiUserID, arg.State, arg.ID)
-	return err
+func (q *Queries) AcceptSubjectPatch(ctx context.Context, arg AcceptSubjectPatchParams) (int64, error) {
+	result, err := q.db.Exec(ctx, acceptSubjectPatch, arg.WikiUserID, arg.State, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const countCharacterPatches = `-- name: CountCharacterPatches :one
@@ -1656,7 +1665,7 @@ func (q *Queries) NextPendingSubjectPatch(ctx context.Context, id uuid.UUID) (uu
 	return id, err
 }
 
-const rejectCharacterPatch = `-- name: RejectCharacterPatch :exec
+const rejectCharacterPatch = `-- name: RejectCharacterPatch :execrows
 update character_patch
 set wiki_user_id  = $1,
     state         = $2,
@@ -1674,14 +1683,17 @@ type RejectCharacterPatchParams struct {
 	ID           uuid.UUID
 }
 
-func (q *Queries) RejectCharacterPatch(ctx context.Context, arg RejectCharacterPatchParams) error {
-	_, err := q.db.Exec(ctx, rejectCharacterPatch,
+func (q *Queries) RejectCharacterPatch(ctx context.Context, arg RejectCharacterPatchParams) (int64, error) {
+	result, err := q.db.Exec(ctx, rejectCharacterPatch,
 		arg.WikiUserID,
 		arg.State,
 		arg.RejectReason,
 		arg.ID,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const rejectEpisodePatch = `-- name: RejectEpisodePatch :exec
@@ -1712,7 +1724,7 @@ func (q *Queries) RejectEpisodePatch(ctx context.Context, arg RejectEpisodePatch
 	return err
 }
 
-const rejectPersonPatch = `-- name: RejectPersonPatch :exec
+const rejectPersonPatch = `-- name: RejectPersonPatch :execrows
 update person_patch
 set wiki_user_id  = $1,
     state         = $2,
@@ -1730,17 +1742,20 @@ type RejectPersonPatchParams struct {
 	ID           uuid.UUID
 }
 
-func (q *Queries) RejectPersonPatch(ctx context.Context, arg RejectPersonPatchParams) error {
-	_, err := q.db.Exec(ctx, rejectPersonPatch,
+func (q *Queries) RejectPersonPatch(ctx context.Context, arg RejectPersonPatchParams) (int64, error) {
+	result, err := q.db.Exec(ctx, rejectPersonPatch,
 		arg.WikiUserID,
 		arg.State,
 		arg.RejectReason,
 		arg.ID,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
-const rejectSubjectPatch = `-- name: RejectSubjectPatch :exec
+const rejectSubjectPatch = `-- name: RejectSubjectPatch :execrows
 update subject_patch
 set wiki_user_id  = $1,
     state         = $2,
@@ -1758,14 +1773,17 @@ type RejectSubjectPatchParams struct {
 	ID           uuid.UUID
 }
 
-func (q *Queries) RejectSubjectPatch(ctx context.Context, arg RejectSubjectPatchParams) error {
-	_, err := q.db.Exec(ctx, rejectSubjectPatch,
+func (q *Queries) RejectSubjectPatch(ctx context.Context, arg RejectSubjectPatchParams) (int64, error) {
+	result, err := q.db.Exec(ctx, rejectSubjectPatch,
 		arg.WikiUserID,
 		arg.State,
 		arg.RejectReason,
 		arg.ID,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const testDelete = `-- name: TestDelete :exec

--- a/db/query.sql
+++ b/db/query.sql
@@ -135,7 +135,7 @@ insert into edit_suggestion (id,
 values ($1, $2, $3, $4, $5, current_timestamp, null);
 
 
--- name: RejectSubjectPatch :exec
+-- name: RejectSubjectPatch :execrows
 update subject_patch
 set wiki_user_id  = $1,
     state         = $2,
@@ -145,7 +145,7 @@ where id = $4
   and deleted_at is null
   and state = 0;
 
--- name: AcceptSubjectPatch :exec
+-- name: AcceptSubjectPatch :execrows
 update subject_patch
 set wiki_user_id = $1,
     state        = $2,
@@ -465,7 +465,7 @@ set original_name    = $2,
     updated_at       = current_timestamp
 where id = $1;
 
--- name: RejectCharacterPatch :exec
+-- name: RejectCharacterPatch :execrows
 update character_patch
 set wiki_user_id  = $1,
     state         = $2,
@@ -475,7 +475,7 @@ where id = $4
   and deleted_at is null
   and state = 0;
 
--- name: RejectPersonPatch :exec
+-- name: RejectPersonPatch :execrows
 update person_patch
 set wiki_user_id  = $1,
     state         = $2,
@@ -485,7 +485,7 @@ where id = $4
   and deleted_at is null
   and state = 0;
 
--- name: AcceptCharacterPatch :exec
+-- name: AcceptCharacterPatch :execrows
 update character_patch
 set wiki_user_id = $1,
     state        = $2,
@@ -494,7 +494,7 @@ where id = $3
   and deleted_at is null
   and state = 0;
 
--- name: AcceptPersonPatch :exec
+-- name: AcceptPersonPatch :execrows
 update person_patch
 set wiki_user_id = $1,
     state        = $2,

--- a/person-review.go
+++ b/person-review.go
@@ -108,7 +108,7 @@ func (h *handler) handlePersonApprove(w http.ResponseWriter, r *http.Request, qx
 		}
 
 		if errRes.Code == ErrCodeInvalidWikiSyntax {
-			err = qx.RejectPersonPatch(r.Context(), dal.RejectPersonPatchParams{
+			_, err = qx.RejectPersonPatch(r.Context(), dal.RejectPersonPatchParams{
 				WikiUserID:   s.UserID,
 				State:        PatchStateRejected,
 				ID:           patch.ID,
@@ -125,7 +125,7 @@ func (h *handler) handlePersonApprove(w http.ResponseWriter, r *http.Request, qx
 		}
 
 		if errRes.Code == ErrCodeWikiChanged {
-			err = qx.RejectPersonPatch(r.Context(), dal.RejectPersonPatchParams{
+			_, err = qx.RejectPersonPatch(r.Context(), dal.RejectPersonPatchParams{
 				WikiUserID:   s.UserID,
 				State:        PatchStateOutdated,
 				ID:           patch.ID,
@@ -142,7 +142,7 @@ func (h *handler) handlePersonApprove(w http.ResponseWriter, r *http.Request, qx
 		}
 
 		if errRes.Code == ErrCodeItemLocked {
-			err = qx.RejectPersonPatch(r.Context(), dal.RejectPersonPatchParams{
+			_, err = qx.RejectPersonPatch(r.Context(), dal.RejectPersonPatchParams{
 				WikiUserID:   s.UserID,
 				State:        PatchStateRejected,
 				ID:           patch.ID,
@@ -159,7 +159,7 @@ func (h *handler) handlePersonApprove(w http.ResponseWriter, r *http.Request, qx
 		}
 
 		if errRes.Code == ErrCodeValidationError {
-			err = qx.RejectPersonPatch(r.Context(), dal.RejectPersonPatchParams{
+			_, err = qx.RejectPersonPatch(r.Context(), dal.RejectPersonPatchParams{
 				WikiUserID:   s.UserID,
 				State:        PatchStateRejected,
 				ID:           patch.ID,
@@ -177,7 +177,7 @@ func (h *handler) handlePersonApprove(w http.ResponseWriter, r *http.Request, qx
 		return errors.New("failed to submit patch")
 	}
 
-	err = qx.AcceptPersonPatch(context.WithoutCancel(r.Context()), dal.AcceptPersonPatchParams{
+	_, err = qx.AcceptPersonPatch(context.WithoutCancel(r.Context()), dal.AcceptPersonPatchParams{
 		WikiUserID: s.UserID,
 		State:      PatchStateAccepted,
 		ID:         patch.ID,
@@ -203,7 +203,7 @@ func (h *handler) handlePersonApprove(w http.ResponseWriter, r *http.Request, qx
 }
 
 func (h *handler) handlePersonReject(w http.ResponseWriter, r *http.Request, qx *dal.Queries, p dal.PersonPatch, s *session.Session) error {
-	err := qx.RejectPersonPatch(r.Context(), dal.RejectPersonPatchParams{
+	_, err := qx.RejectPersonPatch(r.Context(), dal.RejectPersonPatchParams{
 		WikiUserID: s.UserID,
 		State:      PatchStateRejected,
 		ID:         p.ID,

--- a/subject-review.go
+++ b/subject-review.go
@@ -117,7 +117,7 @@ func (h *handler) handleSubjectApprove(w http.ResponseWriter, r *http.Request, q
 		}
 
 		if errRes.Code == ErrCodeInvalidWikiSyntax {
-			err = qx.RejectSubjectPatch(r.Context(), dal.RejectSubjectPatchParams{
+			_, err = qx.RejectSubjectPatch(r.Context(), dal.RejectSubjectPatchParams{
 				WikiUserID:   s.UserID,
 				State:        PatchStateRejected,
 				ID:           patch.ID,
@@ -134,7 +134,7 @@ func (h *handler) handleSubjectApprove(w http.ResponseWriter, r *http.Request, q
 		}
 
 		if errRes.Code == ErrCodeInvalidMetaTags {
-			err = qx.RejectSubjectPatch(r.Context(), dal.RejectSubjectPatchParams{
+			_, err = qx.RejectSubjectPatch(r.Context(), dal.RejectSubjectPatchParams{
 				WikiUserID:   s.UserID,
 				State:        PatchStateRejected,
 				ID:           patch.ID,
@@ -151,7 +151,7 @@ func (h *handler) handleSubjectApprove(w http.ResponseWriter, r *http.Request, q
 		}
 
 		if errRes.Code == ErrCodeWikiChanged {
-			err = qx.RejectSubjectPatch(r.Context(), dal.RejectSubjectPatchParams{
+			_, err = qx.RejectSubjectPatch(r.Context(), dal.RejectSubjectPatchParams{
 				WikiUserID:   s.UserID,
 				State:        PatchStateOutdated,
 				ID:           patch.ID,
@@ -168,7 +168,7 @@ func (h *handler) handleSubjectApprove(w http.ResponseWriter, r *http.Request, q
 		}
 
 		if errRes.Code == ErrCodeItemLocked {
-			err = qx.RejectSubjectPatch(r.Context(), dal.RejectSubjectPatchParams{
+			_, err = qx.RejectSubjectPatch(r.Context(), dal.RejectSubjectPatchParams{
 				WikiUserID:   s.UserID,
 				State:        PatchStateRejected,
 				ID:           patch.ID,
@@ -185,7 +185,7 @@ func (h *handler) handleSubjectApprove(w http.ResponseWriter, r *http.Request, q
 		}
 
 		if errRes.Code == ErrCodeValidationError {
-			err = qx.RejectSubjectPatch(r.Context(), dal.RejectSubjectPatchParams{
+			_, err = qx.RejectSubjectPatch(r.Context(), dal.RejectSubjectPatchParams{
 				WikiUserID:   s.UserID,
 				State:        PatchStateRejected,
 				ID:           patch.ID,
@@ -203,7 +203,7 @@ func (h *handler) handleSubjectApprove(w http.ResponseWriter, r *http.Request, q
 		return errors.New("failed to submit patch")
 	}
 
-	err = qx.AcceptSubjectPatch(context.WithoutCancel(r.Context()), dal.AcceptSubjectPatchParams{
+	_, err = qx.AcceptSubjectPatch(context.WithoutCancel(r.Context()), dal.AcceptSubjectPatchParams{
 		WikiUserID: s.UserID,
 		State:      PatchStateAccepted,
 		ID:         patch.ID,
@@ -229,7 +229,7 @@ func (h *handler) handleSubjectApprove(w http.ResponseWriter, r *http.Request, q
 }
 
 func (h *handler) handleSubjectReject(w http.ResponseWriter, r *http.Request, qx *dal.Queries, p dal.SubjectPatch, s *session.Session) error {
-	err := qx.RejectSubjectPatch(r.Context(), dal.RejectSubjectPatchParams{
+	_, err := qx.RejectSubjectPatch(r.Context(), dal.RejectSubjectPatchParams{
 		WikiUserID: s.UserID,
 		State:      PatchStateRejected,
 		ID:         p.ID,


### PR DESCRIPTION
## Problem

When a reviewer accepts a patch, the review flow calls the external wiki API **while holding a `FOR UPDATE` row lock** on the patch (subject/character/person). The API write immediately produces a binlog event. The canal (Debezium CDC) consumer can process that event **before the local transaction commits**, so it sees the patch as still `pending` and judges it outdated.

The patch row lock makes canal's `UPDATE ... WHERE state = 0` block until the accept transaction commits; after commit `state` is no longer `pending`, so the update affects **zero rows**. But the Reject/Accept queries were generated as `:exec` and ignored `RowsAffected`, so canal still sent an "expired" notification — the user received both an expired and an accepted notification for the same patch.

## Fix

- Change `RejectSubjectPatch` / `RejectCharacterPatch` / `RejectPersonPatch` and `AcceptSubjectPatch` / `AcceptCharacterPatch` / `AcceptPersonPatch` from `:exec` to `:execrows` (return affected row count).
- In `canal.go`, check the affected row count and skip the expired notification when it is 0 (the patch state was changed by another flow, e.g. accepted).
- The review flow keeps its original transaction structure (`FOR UPDATE` + API call inside the transaction), so there is no intermediate "processing" state that could be left behind after a crash — row locks are released automatically on rollback.

## Verification

- `go build ./...`, `go vet ./...`, `golangci-lint-v2 run ./...`, `go test ./...` all pass.
- Note: `dal/query.sql.go` was updated manually to match sqlc's `:execrows` output (no sqlc/DB available in this environment); run `task gen` in an environment with a database to confirm there is no diff.